### PR TITLE
Integrate AG-UI protocol streaming between UI and backend

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ export default [
     ignores: [
       "**/*.d.ts",
       "packages/backend/generated/**",
+      "packages/backend/src/generated/**",
       "packages/frontend/playwright.config.ts",
       "packages/frontend/vite.config.ts",
       "**/*.spec.ts",

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./models/Agent";
 export * from "./models/Chat";
 export * from "./models/interfaces";
+export * from "./models/agui";

--- a/packages/common/src/models/agui.ts
+++ b/packages/common/src/models/agui.ts
@@ -1,0 +1,81 @@
+export type AGUIMessageRole = "user" | "assistant" | "system";
+
+export type AGUIRunStatus = "SUCCESS" | "ERROR";
+
+export interface AGUIEventBase<TType extends string> {
+  type: TType;
+  /**
+   * Unique identifier for this event instance.
+   */
+  eventId: string;
+  /**
+   * Identifier for the run that emitted this event.
+   */
+  runId: string;
+  /**
+   * ISO 8601 timestamp representing when the event was emitted.
+   */
+  createdAt: string;
+}
+
+export interface AGUIRunStartedEvent extends AGUIEventBase<"RUN_STARTED"> {
+  run: {
+    /**
+     * Unique identifier for the run.
+     */
+    id: string;
+    /**
+     * Identifier that groups all events that belong to the same logical run hierarchy.
+     */
+    rootId: string;
+    /**
+     * Identifier for the parent run when the current run is nested.
+     */
+    parentId?: string;
+    /**
+     * Optional human readable name for the run.
+     */
+    name?: string;
+    /**
+     * Arbitrary metadata provided by the agent.
+     */
+    metadata?: Record<string, unknown>;
+  };
+}
+
+export interface AGUITextMessageChunkEvent
+  extends AGUIEventBase<"TEXT_MESSAGE_CHUNK"> {
+  message: {
+    id: string;
+    role: AGUIMessageRole;
+  };
+  delta: {
+    text: string;
+  };
+}
+
+export interface AGUIRunFinishedEvent extends AGUIEventBase<"RUN_FINISHED"> {
+  result: {
+    status: AGUIRunStatus;
+    message?: {
+      id: string;
+      role: AGUIMessageRole;
+      content: string;
+    };
+    metadata?: Record<string, unknown>;
+  };
+}
+
+export interface AGUIRunErrorEvent extends AGUIEventBase<"RUN_ERROR"> {
+  error: {
+    message: string;
+    code?: string;
+    details?: Record<string, unknown>;
+  };
+}
+
+export type AGUIEvent =
+  | AGUIRunStartedEvent
+  | AGUITextMessageChunkEvent
+  | AGUIRunFinishedEvent
+  | AGUIRunErrorEvent;

--- a/packages/frontend/src/services/chatService.ts
+++ b/packages/frontend/src/services/chatService.ts
@@ -1,4 +1,11 @@
-import { ChatMessage as CommonChatMessage } from "@llmops-demo/common"; // Import common ChatMessage
+import {
+  ChatMessage as CommonChatMessage,
+  ChatRequest as CommonChatRequest,
+  AGUIRunStartedEvent,
+  AGUITextMessageChunkEvent,
+  AGUIRunFinishedEvent,
+  AGUIRunErrorEvent,
+} from "@llmops-demo/common"; // Shared models
 
 export interface UIChatMessage {
   id: string;
@@ -6,60 +13,276 @@ export interface UIChatMessage {
   fromUser: boolean;
 }
 
-export interface ChatRequest {
-  message: string;
-  history: Array<{
-    role: "user" | "assistant";
-    content: string;
-  }>;
-  agentType?: string;
-  modelName?: string;
-}
-
 export interface AgentType {
   name: string;
   description: string;
+}
+
+export interface ChatStreamHandlers {
+  onRunStarted?: (event: AGUIRunStartedEvent) => void;
+  onTextChunk?: (chunk: string, event: AGUITextMessageChunkEvent) => void;
+  onRunFinished?: (event: AGUIRunFinishedEvent) => void;
+  onRunError?: (event: AGUIRunErrorEvent) => void;
+  onEvent?: (eventName: string, payload: unknown) => void;
+}
+
+interface SSEEvent {
+  event: string;
+  data?: string;
+  id?: string;
 }
 
 // Temporarily removed debugLog utility as part of phased refactor.
 // It will be re-added if necessary after core reactivity issue is resolved.
 
 export class ChatService {
+  private static mapHistoryToCommon(
+    history: UIChatMessage[],
+  ): CommonChatMessage[] {
+    return history.map(
+      (message): CommonChatMessage => ({
+        role: message.fromUser ? "user" : "assistant",
+        content: message.text ?? "",
+      }),
+    );
+  }
+
+  private static parseSSEEvent(rawEvent: string): SSEEvent | null {
+    const lines = rawEvent.split("\n");
+    let eventName = "message";
+    const dataLines: string[] = [];
+    let id: string | undefined;
+
+    for (const line of lines) {
+      if (!line) {
+        continue;
+      }
+
+      if (line.startsWith(":")) {
+        continue;
+      }
+
+      const separatorIndex = line.indexOf(":");
+      if (separatorIndex === -1) {
+        continue;
+      }
+
+      const field = line.slice(0, separatorIndex).trim();
+      const value = line.slice(separatorIndex + 1).trimStart();
+
+      switch (field) {
+        case "event":
+          if (value) {
+            eventName = value;
+          }
+          break;
+        case "data":
+          dataLines.push(value);
+          break;
+        case "id":
+          id = value;
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (!id && dataLines.length === 0 && eventName === "message") {
+      return null;
+    }
+
+    return {
+      event: eventName || "message",
+      data: dataLines.length > 0 ? dataLines.join("\n") : undefined,
+      id,
+    };
+  }
+
   static async sendMessage(
     message: string,
     history: UIChatMessage[],
     agentType: string = "default",
-    modelName: string = "gemini-2.5-flash", // Add modelName parameter
-    sessionId?: string, // Add sessionId parameter
+    modelName: string = "gemini-2.5-flash",
+    sessionId?: string,
+    handlers: ChatStreamHandlers = {},
   ): Promise<string> {
-    const response = await fetch("/api/chat", {
+    const payload: CommonChatRequest = {
+      message,
+      history: ChatService.mapHistoryToCommon(history),
+      agentType,
+      modelName,
+      sessionId,
+    };
+
+    const response = await fetch("/api/chat/stream", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        message,
-        history: history.map(
-          (m): CommonChatMessage => ({
-            role: m.fromUser ? "user" : "assistant",
-            content: m.text || "", // Ensure content is always a string
-          }),
-        ),
-        agentType,
-        modelName,
-        sessionId, // Pass sessionId
-      } as ChatRequest),
+      body: JSON.stringify(payload),
     });
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(
-        `Failed to send message: ${response.status} ${response.statusText} - ${errorText}`,
+        `Failed to start chat stream: ${response.status} ${response.statusText} - ${errorText}`,
       );
     }
 
-    const data = await response.json();
-    return data.chunk;
+    if (!response.body) {
+      throw new Error(
+        "Streaming is not supported in this environment. Please use a modern browser.",
+      );
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder("utf-8");
+    let buffer = "";
+    let aggregatedText = "";
+    let runCompleted = false;
+    let shouldClose = false;
+
+    const invokeEventHandler = (eventName: string, payload: unknown) => {
+      if (handlers.onEvent) {
+        try {
+          handlers.onEvent(eventName, payload);
+        } catch (handlerError) {
+          console.warn("ChatService onEvent handler threw an error", handlerError);
+        }
+      }
+    };
+
+    const handleParsedEvent = async (event: SSEEvent, payload: unknown) => {
+      invokeEventHandler(event.event, payload);
+
+      switch (event.event) {
+        case "RUN_STARTED": {
+          if (handlers.onRunStarted && payload && typeof payload === "object") {
+            handlers.onRunStarted(payload as AGUIRunStartedEvent);
+          }
+          break;
+        }
+        case "TEXT_MESSAGE_CHUNK": {
+          if (payload && typeof payload === "object") {
+            const chunkEvent = payload as AGUITextMessageChunkEvent;
+            const deltaText = chunkEvent?.delta?.text ?? "";
+            if (deltaText) {
+              aggregatedText += deltaText;
+              handlers.onTextChunk?.(deltaText, chunkEvent);
+            }
+          }
+          break;
+        }
+        case "RUN_FINISHED": {
+          if (payload && typeof payload === "object") {
+            const finishedEvent = payload as AGUIRunFinishedEvent;
+            handlers.onRunFinished?.(finishedEvent);
+            const finalContent = finishedEvent?.result?.message?.content;
+            if (typeof finalContent === "string") {
+              aggregatedText = finalContent;
+            }
+          }
+          runCompleted = true;
+          shouldClose = true;
+          break;
+        }
+        case "RUN_ERROR": {
+          if (payload && typeof payload === "object") {
+            const errorEvent = payload as AGUIRunErrorEvent;
+            handlers.onRunError?.(errorEvent);
+            const errorMessage =
+              errorEvent?.error?.message ||
+              "An unknown error occurred while processing the request.";
+            throw new Error(errorMessage);
+          }
+          throw new Error(
+            "An unknown error occurred while processing the request.",
+          );
+        }
+        default:
+          break;
+      }
+    };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+
+        if (done) {
+          buffer += decoder.decode(new Uint8Array(), { stream: false });
+          break;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+        buffer = buffer.replace(/\r\n/g, "\n");
+
+        let boundaryIndex = buffer.indexOf("\n\n");
+
+        while (boundaryIndex !== -1) {
+          const rawEvent = buffer.slice(0, boundaryIndex);
+          buffer = buffer.slice(boundaryIndex + 2);
+
+          if (rawEvent.length === 0) {
+            boundaryIndex = buffer.indexOf("\n\n");
+            continue;
+          }
+
+          const parsedEvent = ChatService.parseSSEEvent(rawEvent);
+          if (!parsedEvent || !parsedEvent.data) {
+            boundaryIndex = buffer.indexOf("\n\n");
+            continue;
+          }
+
+          let parsedPayload: unknown = parsedEvent.data;
+          try {
+            parsedPayload = JSON.parse(parsedEvent.data);
+          } catch {
+            // Non-JSON payloads are ignored for typed handlers but still passed to onEvent
+          }
+
+          await handleParsedEvent(parsedEvent, parsedPayload);
+
+          if (shouldClose) {
+            break;
+          }
+
+          boundaryIndex = buffer.indexOf("\n\n");
+        }
+
+        if (shouldClose) {
+          break;
+        }
+      }
+
+      if (!shouldClose && buffer.length > 0) {
+        const parsedEvent = ChatService.parseSSEEvent(buffer);
+        if (parsedEvent && parsedEvent.data) {
+          let parsedPayload: unknown = parsedEvent.data;
+          try {
+            parsedPayload = JSON.parse(parsedEvent.data);
+          } catch {
+            // Ignore JSON parse errors for trailing payloads
+          }
+          await handleParsedEvent(parsedEvent, parsedPayload);
+        }
+      }
+    } catch (streamError) {
+      await reader.cancel().catch(() => undefined);
+      throw streamError;
+    } finally {
+      if (shouldClose) {
+        await reader.cancel().catch(() => undefined);
+      }
+      if (typeof reader.releaseLock === "function") {
+        reader.releaseLock();
+      }
+    }
+
+    if (!runCompleted) {
+      throw new Error("Stream ended before the run completed.");
+    }
+
+    return aggregatedText;
   }
 
   static async getAgentTypes(): Promise<AgentType[]> {

--- a/packages/frontend/src/stores/messageStore.ts
+++ b/packages/frontend/src/stores/messageStore.ts
@@ -18,6 +18,14 @@ export const useMessageStore = defineStore("messageStore", {
         }
       }
     },
+    setLastMessageText(text: string) {
+      if (this.messages.length > 0) {
+        const lastMessage = this.messages[this.messages.length - 1];
+        if (!lastMessage.fromUser) {
+          lastMessage.text = text;
+        }
+      }
+    },
     setIsLoading(loading: boolean) {
       this.isLoading = loading;
     },


### PR DESCRIPTION
## Summary
- add shared AG-UI protocol event definitions to the common package
- stream AG-UI compliant run events from the backend SSE endpoint
- consume the AG-UI stream in the Vue chat client, updating the store for incremental responses, and ignore generated routes in eslint

## Testing
- pnpm --filter @llmops-demo/common build
- pnpm --filter @llmops-demo-ts/backend build
- pnpm --filter @llmops-demo-ts/frontend build
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc74240df8832cb7ff8c8dfd94683e